### PR TITLE
bye, mp_module_get_loaded_or_builtin

### DIFF
--- a/usqlite_file.c
+++ b/usqlite_file.c
@@ -35,7 +35,7 @@ extern const mp_obj_module_t mp_module_io;
 // ------------------------------------------------------------------------------
 
 bool usqlite_file_exists(const char *pathname) {
-    mp_obj_t os = mp_module_get_loaded_or_builtin(MP_QSTR_uos);
+    mp_obj_t os = mp_module_get_builtin(MP_QSTR_uos, 0);
     mp_obj_t ilistdir = usqlite_method(os, MP_QSTR_ilistdir);
 
     char path[MAXPATHNAME + 1];
@@ -235,7 +235,7 @@ int usqlite_file_delete(const char *pathname) {
     usqlite_logprintf("%s: %s\n", __func__, pathname);
 
     mp_obj_t filename = mp_obj_new_str(pathname, strlen(pathname));
-    mp_obj_t remove = usqlite_method(mp_module_get_loaded_or_builtin(MP_QSTR_uos), MP_QSTR_remove);
+    mp_obj_t remove = usqlite_method(mp_module_get_builtin(MP_QSTR_uos, 0), MP_QSTR_remove);
     mp_call_function_1(remove, filename);
 
     return SQLITE_OK;


### PR DESCRIPTION
the micropython people got rid of "mp_module_get_loaded_or_builtin" but added "mp_module_get_builti"n, which takes a boolean as a second argument.  This gets usqlite to run against current micropython.