### PR TITLE
Update the usqlite_Error class

### DIFF
--- a/usqlite_module.c
+++ b/usqlite_module.c
@@ -207,6 +207,8 @@ static const mp_rom_map_elem_t usqlite_module_globals_table[] =
     { MP_ROM_QSTR(MP_QSTR_mem_peak),                MP_ROM_PTR(&usqlite_mem_peak_obj) },
     { MP_ROM_QSTR(MP_QSTR_mem_current),             MP_ROM_PTR(&usqlite_mem_current_obj) },
     { MP_ROM_QSTR(MP_QSTR_mem_status),              MP_ROM_PTR(&usqlite_mem_status_obj) },
+
+    { MP_ROM_QSTR(MP_QSTR_usqlite_Error),           MP_ROM_PTR(&usqlite_Error) },
 };
 
 static MP_DEFINE_CONST_DICT(usqlite_module_globals, usqlite_module_globals_table);

--- a/usqlite_utils.c
+++ b/usqlite_utils.c
@@ -68,7 +68,8 @@ MP_DEFINE_CONST_OBJ_TYPE(
     MP_TYPE_FLAG_ITER_IS_GETITER,
     make_new, mp_obj_exception_make_new,
     print, mp_obj_exception_print,
-    attr, mp_obj_exception_attr
+    attr, mp_obj_exception_attr,
+    parent, &mp_type_Exception
     );
 #else
 const mp_obj_type_t usqlite_Error = {
@@ -77,6 +78,7 @@ const mp_obj_type_t usqlite_Error = {
     .print = mp_obj_exception_print,
     .make_new = mp_obj_exception_make_new,
     .attr = mp_obj_exception_attr,
+    .parent = &mp_type_Exception
 };
 #endif
 


### PR DESCRIPTION
In the current implementation, the **try/except** statement cannot catch the _usqlite_Error_ unless we use a bare _except_

```py
import usqlite

con = usqlite.connect("data.db")
try:
   con.execute("COMMIT;")
except:
   pass
con.close()
```

In this update, I added the _Exception_ type as the parent class of the _usqlite_Error_. So, we can catch the exception as _Exception_ type
```py
import usqlite

con = usqlite.connect("data.db")
try:
   con.execute("COMMIT;")
except Exception as e:
   pass
con.close()
```

Additionally, I also added the usqlite_Error to the global objects so the user can catch the _usqlite_Error_ directly
```py
import usqlite

con = usqlite.connect("data.db")
try:
   con.execute("COMMIT;")
except usqlite.usqlite_Error as e:
   pass
con.close()
```