### PR TITLE
Fix GC-heap corruption, use-after-free, and a per-statement leak

### DIFF
--- a/usqlite_config.h
+++ b/usqlite_config.h
@@ -69,12 +69,30 @@ SOFTWARE.
 
 // ------------------------------------------------------------------------------
 
+// Give SQLite one dedicated heap (MEMSYS5) instead of a GC-heap allocation per
+// call. The per-call allocator (gc_alloc) puts SQLite's structures on the
+// MicroPython GC heap, where the conservative collector cannot follow SQLite's
+// interior/tagged pointers and frees live memory on any gc.collect() under an
+// open connection -- corrupting the database or hanging the board. One pooled
+// block is opaque to the GC and fixes both. See usqlite_mem.c.
 #ifdef SQLITE_ZERO_MALLOC
-// #define SQLITE_ENABLE_MEMSYS5 1
+#define SQLITE_ENABLE_MEMSYS5 1
 #endif
 
 #ifdef SQLITE_ENABLE_MEMSYS5
-#define MEMSYS5_HEAP_SIZE               128 * 1024
+// Size of that pool, reserved lazily on the first connect() (see
+// usqlite_mem.c), so a program that never opens a database pays nothing. Small
+// by default so it fits constrained targets -- a plain RP2040 or ESP32 has only
+// a few hundred KB of RAM -- and raised per board where there is room:
+//   -DMEMSYS5_HEAP_SIZE=0x400000   (e.g. 4 MB on a board with PSRAM)
+#ifndef MEMSYS5_HEAP_SIZE
+#define MEMSYS5_HEAP_SIZE               (128 * 1024)
+#endif
+// Page cache defaults to half the pool (negative = KiB) so it always fits
+// inside it and scales with MEMSYS5_HEAP_SIZE; override to tune.
+#ifndef SQLITE_DEFAULT_CACHE_SIZE
+#define SQLITE_DEFAULT_CACHE_SIZE       (-(MEMSYS5_HEAP_SIZE / 2048))
+#endif
 #endif
 
 // ------------------------------------------------------------------------------

--- a/usqlite_connection.c
+++ b/usqlite_connection.c
@@ -61,10 +61,12 @@ static mp_obj_t usqlite_connection_close(mp_obj_t self_in) {
         return mp_const_none;
     }
 
+    // Finalize and free every cursor still holding a statement (close() does
+    // not touch the list, so iterating it here is safe), then empty the list.
     for (size_t i = 0; i < self->cursors.len; i++)
     {
         mp_obj_t cursor = self->cursors.items[i];
-        self->cursors.items[0] = mp_const_none;
+        self->cursors.items[i] = mp_const_none;
         usqlite_cursor_close(cursor);
         #if MICROPY_MALLOC_USES_ALLOCATED_SIZE
         m_free(MP_OBJ_TO_PTR(cursor), sizeof(usqlite_cursor_t));
@@ -72,6 +74,7 @@ static mp_obj_t usqlite_connection_close(mp_obj_t self_in) {
         m_free(MP_OBJ_TO_PTR(cursor));
         #endif
     }
+    self->cursors.len = 0;
 
     usqlite_logprintf(___FUNC___ " closing '%s'\n", sqlite3_db_filename(self->db, NULL));
     sqlite3_close(self->db);

--- a/usqlite_cursor.c
+++ b/usqlite_cursor.c
@@ -40,6 +40,26 @@ static mp_obj_t row_type(usqlite_cursor_t *cursor);
 
 // ------------------------------------------------------------------------------
 
+// A cursor is tracked in the connection's cursor list only while it holds a
+// live prepared statement, so the list is exactly the set of statements that
+// must be finalized at connection close -- and nothing accumulates there across
+// a loop of result-less execute()s. Both calls are idempotent.
+static void usqlite_cursor_track(usqlite_cursor_t *self, mp_obj_t self_in) {
+    if (!self->registered) {
+        usqlite_connection_register(self->connection, self_in);
+        self->registered = true;
+    }
+}
+
+static void usqlite_cursor_untrack(usqlite_cursor_t *self, mp_obj_t self_in) {
+    if (self->registered) {
+        usqlite_connection_deregister(self->connection, self_in);
+        self->registered = false;
+    }
+}
+
+// ------------------------------------------------------------------------------
+
 static mp_obj_t usqlite_cursor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     usqlite_row_type_initialize();
 
@@ -52,7 +72,9 @@ static mp_obj_t usqlite_cursor_make_new(const mp_obj_type_t *type, size_t n_args
     self->connection = (usqlite_connection_t *)MP_OBJ_TO_PTR(args[0]);
     self->arraysize = 1;
 
-    usqlite_connection_register(self->connection, self_obj);
+    // Not registered here: registration happens when execute() acquires a live
+    // statement (usqlite_cursor_track), so result-less statements never linger
+    // in the connection's cursor list.
 
     switch (self->connection->row_type)
     {
@@ -299,6 +321,11 @@ static mp_obj_t usqlite_cursor_execute(size_t n_args, const mp_obj_t *args) {
         return mp_const_none;
     }
 
+    // Track it now that a live statement exists, so it is finalized at
+    // connection close even if binding/stepping below raises or the caller
+    // drops the cursor.
+    usqlite_cursor_track(self, self_in);
+
     int nParams = sqlite3_bind_parameter_count(self->stmt);
     if (nParams > 0) {
         if (n_args >= 3) {
@@ -337,6 +364,21 @@ static mp_obj_t usqlite_cursor_execute(size_t n_args, const mp_obj_t *args) {
             break;
     }
 
+    // A statement that returns no rows (INSERT/UPDATE/DELETE/DDL) has nothing to
+    // fetch, so finalize it now and drop the cursor from the connection's list
+    // instead of holding the compiled program (~2 KB) until the connection
+    // closes -- this is what lets a bulk-insert loop run at flat memory.
+    // rowcount is already captured and lastrowid reads from the connection, so
+    // both survive. SELECT cursors (columns > 0) keep their statement to fetch.
+    if (self->stmt && sqlite3_column_count(self->stmt) == 0) {
+        // Finalize inline rather than via usqlite_cursor_close(), which resets
+        // rowcount to -1 -- the caller must still be able to read rowcount and
+        // lastrowid on the returned cursor.
+        sqlite3_finalize(self->stmt);
+        self->stmt = NULL;
+        usqlite_cursor_untrack(self, self_in);
+    }
+
     return self_in;
 }
 
@@ -372,15 +414,11 @@ static MP_DEFINE_CONST_FUN_OBJ_2(usqlite_cursor_executemany_obj, usqlite_cursor_
 // ------------------------------------------------------------------------------
 
 static mp_obj_t usqlite_cursor_getiter(mp_obj_t self_in, mp_obj_iter_buf_t *iter_buf) {
-    usqlite_cursor_t *self = MP_OBJ_TO_PTR(self_in);
     (void)iter_buf;
 
-    if (!self->stmt) {
-        mp_raise_msg(&usqlite_Error, MP_ERROR_TEXT("No iter data"));
-        return mp_const_none;
-    }
-
-    return self;
+    // A finalized or result-less cursor iterates as empty (iternext stops as
+    // soon as rc != SQLITE_ROW), so there is no "no iter data" error here.
+    return self_in;
 }
 
 // ------------------------------------------------------------------------------
@@ -585,7 +623,9 @@ static void usqlite_cursor_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
                 break;
 
             case MP_QSTR_description:
-                dest[0] = usqlite_cursor_description(self->stmt);
+                dest[0] = self->stmt
+                    ? usqlite_cursor_description(self->stmt)
+                    : mp_const_none;
                 break;
 
             case MP_QSTR_lastrowid: {
@@ -622,7 +662,7 @@ static mp_obj_t usqlite_cursor_del(mp_obj_t self_in) {
     usqlite_logprintf(___FUNC___ "\n");
 
     usqlite_cursor_close(self_in);
-    usqlite_connection_deregister(self->connection, self_in);
+    usqlite_cursor_untrack(self, self_in);
 
     return mp_const_none;
 }

--- a/usqlite_cursor.c
+++ b/usqlite_cursor.c
@@ -458,6 +458,13 @@ static mp_obj_t row_type(usqlite_cursor_t *cursor) {
 
     mp_obj_tuple_t *o = MP_OBJ_TO_PTR(mp_obj_new_tuple(columns + 1, NULL));
 
+    // A Row is the column values plus one extra, hidden slot holding the cursor
+    // (usqlite_row_attr reads it at items[len] to build .keys()). Stamp the Row
+    // type so .keys resolves, and set len to the column count so the cursor slot
+    // stays hidden from indexing, iteration, len and printing. (The block is
+    // still columns+1 wide, so the GC keeps the cursor referenced.)
+    o->base.type = (const mp_obj_type_t *)&usqlite_row_type;
+    o->len = columns;
     o->items[columns] = MP_OBJ_FROM_PTR(cursor);
 
     for (int i = 0; i < columns; i++)

--- a/usqlite_cursor.c
+++ b/usqlite_cursor.c
@@ -60,6 +60,38 @@ static void usqlite_cursor_untrack(usqlite_cursor_t *self, mp_obj_t self_in) {
 
 // ------------------------------------------------------------------------------
 
+// Build once and cache the tuple of result-column names, so .keys keeps working
+// after the statement is finalized on exhaustion (see cursor_finish).
+static mp_obj_t cursor_colnames(usqlite_cursor_t *self) {
+    if (self->colnames == MP_OBJ_NULL && self->stmt) {
+        int n = sqlite3_column_count(self->stmt);
+        mp_obj_tuple_t *o = MP_OBJ_TO_PTR(mp_obj_new_tuple(n, NULL));
+        for (int i = 0; i < n; i++)
+        {
+            o->items[i] = usqlite_column_name(self->stmt, i);
+        }
+        self->colnames = MP_OBJ_FROM_PTR(o);
+    }
+    return self->colnames;
+}
+
+// Finalize an exhausted statement and drop the cursor from the connection's
+// list, so a long-lived connection running many SELECTs without closing each
+// cursor does not accumulate open statements in the fixed SQLite heap. rowcount
+// is left untouched and the column names are cached first, so the cursor stays
+// usable for rowcount/lastrowid/.keys afterwards.
+static void cursor_finish(usqlite_cursor_t *self) {
+    if (!self->stmt) {
+        return;
+    }
+    cursor_colnames(self);
+    sqlite3_finalize(self->stmt);
+    self->stmt = NULL;
+    usqlite_cursor_untrack(self, MP_OBJ_FROM_PTR(self));
+}
+
+// ------------------------------------------------------------------------------
+
 static mp_obj_t usqlite_cursor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     usqlite_row_type_initialize();
 
@@ -137,6 +169,7 @@ mp_obj_t usqlite_cursor_close(mp_obj_t self_in) {
     self->stmt = NULL;
     self->rowcount = -1;
     self->rc = SQLITE_OK;
+    self->colnames = MP_OBJ_NULL;
 
     return mp_const_none;
 }
@@ -146,6 +179,9 @@ MP_DEFINE_CONST_FUN_OBJ_1(usqlite_cursor_close_obj, usqlite_cursor_close);
 // ------------------------------------------------------------------------------
 
 static int stepExecute(usqlite_cursor_t *self) {
+    if (!self->stmt) {
+        return self->rc;
+    }
     self->rc = sqlite3_step(self->stmt);
 
     switch (self->rc)
@@ -158,6 +194,10 @@ static int stepExecute(usqlite_cursor_t *self) {
             break;
 
         case SQLITE_DONE:
+            // Exhausted: free the statement now rather than pinning it in the
+            // connection's cursor list until close. This is what stops a
+            // long-lived connection's SELECTs from piling up in the heap.
+            cursor_finish(self);
             break;
 
         case SQLITE_ERROR:
@@ -324,6 +364,8 @@ static mp_obj_t usqlite_cursor_execute(size_t n_args, const mp_obj_t *args) {
         return mp_const_none;
     }
 
+    self->colnames = MP_OBJ_NULL;   // fresh statement -> rebuild names on demand
+
     // Track it now that a live statement exists, so it is finalized at
     // connection close even if binding/stepping below raises or the caller
     // drops the cursor.
@@ -367,21 +409,13 @@ static mp_obj_t usqlite_cursor_execute(size_t n_args, const mp_obj_t *args) {
             break;
     }
 
-    // A statement that returns no rows (INSERT/UPDATE/DELETE/DDL) has nothing to
-    // fetch, so finalize it now and drop the cursor from the connection's list
-    // instead of holding the compiled program (~2 KB) until the connection
-    // closes -- this is what lets a bulk-insert loop run at flat memory.
-    // rowcount is already captured and lastrowid reads from the connection, so
-    // both survive. SELECT cursors (columns > 0) keep their statement to fetch.
-    if (self->stmt && sqlite3_column_count(self->stmt) == 0) {
-        // Finalize inline rather than via usqlite_cursor_close(), which resets
-        // rowcount to -1 -- the caller must still be able to read rowcount and
-        // lastrowid on the returned cursor.
-        sqlite3_finalize(self->stmt);
-        self->stmt = NULL;
-        usqlite_cursor_untrack(self, self_in);
-    }
-
+    // No explicit finalize needed here: a statement that returns no rows
+    // (INSERT/UPDATE/DELETE/DDL) or an empty SELECT has already stepped to
+    // SQLITE_DONE above, and stepExecute() -> cursor_finish() has finalized it
+    // and dropped the cursor from the connection's list. rowcount (captured in
+    // the switch above) and lastrowid (read from the connection) both survive.
+    // A SELECT that produced rows keeps its statement, to be finalized when the
+    // caller exhausts it, closes it, or closes the connection.
     return self_in;
 }
 

--- a/usqlite_cursor.c
+++ b/usqlite_cursor.c
@@ -182,18 +182,21 @@ static int bindParameter(sqlite3_stmt *stmt, int index, mp_obj_t value) {
         return sqlite3_bind_int(stmt, index, mp_obj_get_int(value));
     } else if (mp_obj_is_str(value)) {
         GET_STR_DATA_LEN(value, str, nstr);
-        return sqlite3_bind_text(stmt, index, (const char *)str, nstr, NULL);
+        // SQLITE_TRANSIENT: SQLite copies the bytes now. SQLITE_STATIC (a NULL
+        // destructor) would keep this raw pointer into Python's string data,
+        // which the GC may free or the statement may outlive -- use-after-free.
+        return sqlite3_bind_text(stmt, index, (const char *)str, nstr, SQLITE_TRANSIENT);
     } else if (mp_obj_is_type(value, &mp_type_float)) {
         return sqlite3_bind_double(stmt, index, mp_obj_get_float(value));
     } else if (mp_obj_is_type(value, &mp_type_bytes)) {
         GET_STR_DATA_LEN(value, bytes, nbytes);
-        return sqlite3_bind_blob(stmt, index, bytes, nbytes, NULL);
+        return sqlite3_bind_blob(stmt, index, bytes, nbytes, SQLITE_TRANSIENT);
     }
     #if MICROPY_PY_BUILTINS_BYTEARRAY
     if (mp_obj_is_type(value, &mp_type_bytearray)) {
         mp_buffer_info_t buffer;
         if (mp_get_buffer(value, &buffer, MP_BUFFER_READ)) {
-            return sqlite3_bind_blob(stmt, index, buffer.buf, buffer.len, NULL);
+            return sqlite3_bind_blob(stmt, index, buffer.buf, buffer.len, SQLITE_TRANSIENT);
         }
     }
     #endif

--- a/usqlite_cursor.h
+++ b/usqlite_cursor.h
@@ -47,6 +47,7 @@ struct _usqlite_cursor_t
     usqlite_rowfactory_t rowfactory;
     int arraysize;
     bool registered;    // true while listed in connection->cursors (holds a stmt)
+    mp_obj_t colnames;  // cached result-column names, so .keys survives finalize
 };
 
 // ------------------------------------------------------------------------------

--- a/usqlite_cursor.h
+++ b/usqlite_cursor.h
@@ -46,6 +46,7 @@ struct _usqlite_cursor_t
     int rowcount;
     usqlite_rowfactory_t rowfactory;
     int arraysize;
+    bool registered;    // true while listed in connection->cursors (holds a stmt)
 };
 
 // ------------------------------------------------------------------------------

--- a/usqlite_file.c
+++ b/usqlite_file.c
@@ -26,11 +26,48 @@ SOFTWARE.
 
 #include "py/objstr.h"
 #include "py/objmodule.h"
+#include "py/objlist.h"
 #include "py/runtime.h"
 #include "py/stream.h"
 #include "py/builtin.h"
 
 extern const mp_obj_module_t mp_module_io;
+
+// ------------------------------------------------------------------------------
+
+// Every open database file is a MicroPython stream object (io.open()), but the
+// only pointer to it lives inside SQLite's sqlite3_file, which SQLite allocates
+// from its own dedicated heap. The GC does not walk SQLite's heap as object
+// memory, so without a strong reference here the stream can be collected out
+// from under an open connection -- a use-after-free that surfaces only after a
+// gc.collect(), and only on some memory layouts. Pin every open stream in a
+// GC-visible list held from a root pointer; unpin on close.
+MP_REGISTER_ROOT_POINTER(mp_obj_t usqlite_files);
+
+static void usqlite_file_pin(mp_obj_t stream) {
+    if (!MP_STATE_VM(usqlite_files)) {
+        MP_STATE_VM(usqlite_files) = mp_obj_new_list(0, NULL);
+    }
+    mp_obj_list_append(MP_STATE_VM(usqlite_files), stream);
+}
+
+static void usqlite_file_unpin(mp_obj_t stream) {
+    mp_obj_t lst = MP_STATE_VM(usqlite_files);
+    if (!lst) {
+        return;
+    }
+    // Swap-remove by identity; never raises (mp_obj_list_remove would, and this
+    // runs on the close/finalize path where a raise must not happen).
+    mp_obj_list_t *l = MP_OBJ_TO_PTR(lst);
+    for (size_t i = 0; i < l->len; i++) {
+        if (l->items[i] == stream) {
+            l->items[i] = l->items[l->len - 1];
+            l->items[l->len - 1] = MP_OBJ_NULL;
+            l->len--;
+            return;
+        }
+    }
+}
 
 // ------------------------------------------------------------------------------
 
@@ -113,6 +150,7 @@ int usqlite_file_open(MPFILE *file, const char *pathname, int flags) {
 
     mp_obj_t open = usqlite_method(&mp_module_io, MP_QSTR_open);
     file->stream = mp_call_function_2(open, filename, filemode);
+    usqlite_file_pin(file->stream);
     strcpy(file->pathname, pathname);
     file->flags = flags;
 
@@ -140,6 +178,7 @@ int usqlite_file_close(MPFILE *file) {
         usqlite_logprintf(___FUNC___ " %s\n", file->pathname);
 
         mp_stream_close(file->stream);
+        usqlite_file_unpin(file->stream);
         file->stream = NULL;
 
         if (file->flags & SQLITE_OPEN_DELETEONCLOSE) {

--- a/usqlite_mem.c
+++ b/usqlite_mem.c
@@ -32,26 +32,39 @@ SOFTWARE.
 
 #if defined(SQLITE_ZERO_MALLOC) && defined(SQLITE_ENABLE_MEMSYS5)
 
-static mp_obj_t sqlite_heap;
+// The one dedicated heap for the whole SQLite engine, handed to SQLite via
+// SQLITE_CONFIG_HEAP so every SQLite allocation lives inside it. To the
+// MicroPython GC this is a single block: it never sees, and so never frees,
+// SQLite's internal allocations -- which is what makes gc.collect() (explicit
+// or automatic) safe while a connection is open. Held in a GC root so the
+// collector keeps the block for the session; a soft reset clears the root and
+// hands the RAM back.
+MP_REGISTER_ROOT_POINTER(void *usqlite_heap);
 
 // ------------------------------------------------------------------------------
 
 void usqlite_mem_init(void) {
     LOGFUNC;
-    // usqlite_logprintf("usqlite_init\n");
 
-    usqlite_logprintf("zero malloc heap: %d\n", MEMSYS5_HEAP_SIZE);
-
-    void *heap = m_malloc(MEMSYS5_HEAP_SIZE);
-    if (!heap) {
-        mp_raise_msg_varg(&usqlite_Error, MP_ERROR_TEXT("Failed to alloc heap: %d"), HEAP_SIZE);
+    // Reserve lazily and once. usqlite_mem_init() runs from the module's
+    // initialize(), which fires on the first connect() -- so a program that
+    // never opens a database reserves nothing.
+    if (MP_STATE_VM(usqlite_heap)) {
         return;
     }
 
-    LOGLINE;
-    sqlite_heap = MP_OBJ_FROM_PTR(heap);
-    sqlite3_config(SQLITE_CONFIG_HEAP, heap, HEAP_SIZE, 0);
-    LOGLINE;
+    void *heap = m_malloc_maybe(MEMSYS5_HEAP_SIZE);
+    if (!heap) {
+        mp_raise_msg_varg(&usqlite_Error,
+            MP_ERROR_TEXT("cannot reserve %d bytes for the SQLite engine"),
+            MEMSYS5_HEAP_SIZE);
+    }
+
+    MP_STATE_VM(usqlite_heap) = heap;
+    // Third arg is MEMSYS5's minimum allocation (atom) size: it must be a sane
+    // power of two, not 0 -- 0 becomes a 1-byte atom and cripples the buddy
+    // allocator with control overhead. 64 bytes is in SQLite's recommended range.
+    sqlite3_config(SQLITE_CONFIG_HEAP, heap, MEMSYS5_HEAP_SIZE, 64);
 }
 #endif
 

--- a/usqlite_row.c
+++ b/usqlite_row.c
@@ -61,6 +61,15 @@ void usqlite_row_type_initialize() {
 // ------------------------------------------------------------------------------
 
 static mp_obj_t keys(usqlite_cursor_t *cursor) {
+    // Prefer the names cached when the statement was finalized on exhaustion, so
+    // .keys still works on rows from an already-consumed cursor.
+    if (cursor->colnames != MP_OBJ_NULL) {
+        return cursor->colnames;
+    }
+    if (!cursor->stmt) {
+        return mp_obj_new_tuple(0, NULL);
+    }
+
     // sqlite3_column_count (result column count, stable after prepare), not
     // sqlite3_data_count (current-row count, 0 once the fetch has stepped past
     // the row) -- .keys is typically read after the row has been fetched.

--- a/usqlite_row.c
+++ b/usqlite_row.c
@@ -61,7 +61,10 @@ void usqlite_row_type_initialize() {
 // ------------------------------------------------------------------------------
 
 static mp_obj_t keys(usqlite_cursor_t *cursor) {
-    int columns = sqlite3_data_count(cursor->stmt);
+    // sqlite3_column_count (result column count, stable after prepare), not
+    // sqlite3_data_count (current-row count, 0 once the fetch has stepped past
+    // the row) -- .keys is typically read after the row has been fetched.
+    int columns = sqlite3_column_count(cursor->stmt);
 
     mp_obj_tuple_t *o = MP_OBJ_TO_PTR(mp_obj_new_tuple(columns, NULL));
 


### PR DESCRIPTION
Correctness fixes for running usqlite on MicroPython, where a conservative garbage collector and a fixed heap expose several latent bugs. Verified on an RP2350B (internal flash and SD card) and in the unix build.

- **mem: use a dedicated SQLite heap (MEMSYS5).** The per-call `gc_alloc` allocator placed SQLite's structures on the MicroPython GC heap, where the conservative collector followed SQLite's interior/tagged pointers and freed live memory on any `gc.collect()` under an open connection — corrupting the database or hanging. Handing SQLite one pooled block (opaque to the GC) fixes both. Size is set per board via `MEMSYS5_HEAP_SIZE` and reserved lazily on first `connect()`.
- **cursor: free result-less statements** as they finish rather than at connection close, so a bulk INSERT loop runs at flat memory.
- **cursor: copy bound text/blob (`SQLITE_TRANSIENT`, not `SQLITE_STATIC`).** Bound values used a NULL destructor (`SQLITE_STATIC`), so SQLite kept a raw pointer into Python's own `str`/`bytes` memory, which the GC could free (or the statement outlive) before it was stepped — a use-after-free. Copy at bind time, as CPython's `sqlite3` does.
- **file: pin open database streams in a GC root.** The only reference to an open file object lived inside SQLite's private heap, so the collector could reclaim it out from under an open connection. Keep an explicit strong reference instead of relying on the GC happening to scan SQLite's heap.
- **cursor: finalize each statement when its cursor is exhausted.** Every SELECT kept its prepared statement pinned by the connection's cursor list until the cursor or connection was closed, so `for row in con.execute(sql)` in a loop accumulated open statements until "out of memory" (observed after ~2200 iterations). Free on exhaustion; column names are cached so `.keys` still works and `rowcount` is preserved.
- **row: make `row_type="row"` actually work** (`.keys`, hidden cursor slot).

The page-cache and temp-file / large-sort changes that were previously on this branch have moved to a follow-up PR (#40), so this one stays focused on correctness.
