### PR TITLE
bindParameter: use mp_obj_is_float() so it builds on MicroPython 1.29+

### DIFF
--- a/usqlite_cursor.c
+++ b/usqlite_cursor.c
@@ -161,7 +161,7 @@ static int bindParameter(sqlite3_stmt *stmt, int index, mp_obj_t value) {
     } else if (mp_obj_is_str(value)) {
         GET_STR_DATA_LEN(value, str, nstr);
         return sqlite3_bind_text(stmt, index, (const char *)str, nstr, NULL);
-    } else if (mp_obj_is_type(value, &mp_type_float)) {
+    } else if (mp_obj_is_float(value)) {
         return sqlite3_bind_double(stmt, index, mp_obj_get_float(value));
     } else if (mp_obj_is_type(value, &mp_type_bytes)) {
         GET_STR_DATA_LEN(value, bytes, nbytes);


### PR DESCRIPTION
`bindParameter()` uses `mp_obj_is_type(value, &mp_type_float)` to detect floats. On MicroPython 1.29+ that trips a compile-time static assert (`mp_type_assert_not_float`): `float` can be a value-encoded type, so there is no `mp_type_float` object to compare a pointer against. The build fails.

Use the portable `mp_obj_is_float(value)` instead — one line, correct on both value-encoded and object floats, and equivalent on earlier versions.

Builds cleanly on MicroPython 1.29+ (verified on the rp2 and unix ports).
